### PR TITLE
mark pod tests as being release candidate tests

### DIFF
--- a/t/pod.t
+++ b/t/pod.t
@@ -3,5 +3,7 @@
 use Test::More;
 eval "use Test::Pod 1.14";
 plan skip_all => "Test::Pod 1.14 required for testing POD" if $@;
+plan skip_all => 'these tests are for release candidate testing'
+  unless $ENV{RELEASE_TESTING};
 diag "Test::Pod version $Test::Pod::VERSION, Pod::Simple version $Pod::Simple::VERSION";
 all_pod_files_ok();


### PR DESCRIPTION
Pod tests check the valdity of pod syntax, not code functionality.
Excluding them unless RELEASE_TESTING is set will prevent any pod errors
from impacting users, even if they somehow make it to the cpan :)
