### PR TITLE
skip taint tests if your perl was built without taint support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,34 +1,43 @@
-3.30
-Clarified $keep flag in doc (patch from DOM)
-Added copyright and license section to pod
-Fixed pod errors (patch from DOM)
+Revision history for Perl module Text::ParseWords
 
-3.29
-Remove pod test from distribution
+3.30_01  2022-04-09  NEILB
+    - Skip taint tests if running under Perl that doesn't support taint
 
-3.28
-Better diag information in pod.t
-More metadata in META.yml
+3.30  2015-03-11  CHORNY
+    - Clarified $keep flag in doc (patch from DOM)
+    - Added copyright and license section to pod
+    - Fixed pod errors (patch from DOM)
 
-3.27 (CPAN version)
-Makefile.PL rewritten
-CHANGES
-pod.t
-5.6 only (regex doesn't work on 5.5.5)
-skip unicode testing on 5.6 in ParseWords.t
-"use strict" in ParseWords.pm
-small changes due to making CPAN version
+3.29  2013-03-17  CHORNY
+    - Remove pod test from distribution
+
+3.28  2013-02-27  CHORNY
+    - Better diag information in pod.t
+    - More metadata in META.yml
+
+3.27  2008-10-26  CHORNY
+    - Makefile.PL rewritten
+    - CHANGES
+    - pod.t
+    - 5.6 only (regex doesn't work on 5.5.5)
+        * skip unicode testing on 5.6 in ParseWords.t
+        * "use strict" in ParseWords.pm
+        * small changes due to making CPAN version
 
 3.26 (perl 5.10)
-better regex in parse_line (demerphq, perl change 31659)
-trailing backslash handling (perl #40921)
+    - better regex in parse_line (demerphq, perl change 31659)
+    - trailing backslash handling (perl #40921)
 
 3.25
-more correct handling of backslashes
+    - more correct handling of backslashes
 
-versions prior to 3.24 include other fixes from core perl
 3.24 (perl 5.8.8)
-taint.t (Alexey Tourbin, perl #33173, perl change 23838)
+    - taint.t (Alexey Tourbin, perl #33173, perl change 23838)
+    - versions prior to 3.24 include other fixes from core perl
 
-3.22
-handling of backslashed newline inside quoted text
+3.22 (not released separately to CPAN)
+    - handling of backslashed newline inside quoted text
+
+3.1  1999-03-22  HALPOM
+    - First CPAN release
+

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Revision history for Perl module Text::ParseWords
 
 3.30_01  2022-04-09  NEILB
     - Skip taint tests if running under Perl that doesn't support taint
+    - Added myself to AUTHORS section and fixed pod warnings in that section
 
 3.30  2015-03-11  CHORNY
     - Clarified $keep flag in doc (patch from DOM)

--- a/CHANGES
+++ b/CHANGES
@@ -5,9 +5,9 @@ Revision history for Perl module Text::ParseWords
     - Added myself to AUTHORS section and fixed pod warnings in that section
 
 3.30  2015-03-11  CHORNY
-    - Clarified $keep flag in doc (patch from DOM)
-    - Added copyright and license section to pod
-    - Fixed pod errors (patch from DOM)
+    - Clarified $keep flag in doc (patch from DOM) (RT#88485)
+    - Added copyright and license section to pod (RT#90483 & RT#90482)
+    - Fixed pod errors (patch from DOM) (RT#91762)
 
 3.29  2013-03-17  CHORNY
     - Remove pod test from distribution

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile1(
     },
     META_MERGE => {
         resources => {
-            repository => 'http://github.com/chorny/Text-ParseWords',
+            repository => 'https://github.com/neilb/Text-ParseWords',
         },
     },
     TEST_REQUIRES => {

--- a/lib/Text/ParseWords.pm
+++ b/lib/Text/ParseWords.pm
@@ -280,19 +280,25 @@ L<Text::CSV> - for parsing CSV files
 
 =head1 AUTHORS
 
-Maintainer: Alexandr Ciornii <alexchornyATgmail.com>.
+Neil Bowers E<lt>neilb@cpan.orgE<gt> (2022-).
 
-Previous maintainer: Hal Pomeranz <pomeranz@netcom.com>, 1994-1997 (Original
-author unknown).  Much of the code for &parse_line() (including the
-primary regexp) from Joerk Behrends <jbehrends@multimediaproduzenten.de>.
+Alexandr Ciornii E<lt>alexchornyATgmail.comE<gt> (2008-2022).
 
-Examples section another documentation provided by John Heidemann 
-<johnh@ISI.EDU>
+Hal Pomeranz E<lt>pomeranz@netcom.comE<gt> (1994-1999).
+
+(Original author unknown).
+
+Much of the code for &parse_line()
+(including the primary regexp)
+from Joerk Behrends E<lt>jbehrends@multimediaproduzenten.deE<gt>.
+
+Examples section and other documentation provided by
+John Heidemann E<lt>johnh@ISI.EDUE<gt>.
 
 Bug reports, patches, and nagging provided by lots of folks-- thanks
-everybody!  Special thanks to Michael Schwern <schwern@envirolink.org>
+everybody!  Special thanks Michael Schwern E<lt>schwern@envirolink.orgE<gt>
 for assuring me that a &nested_quotewords() would be useful, and to 
-Jeff Friedl <jfriedl@yahoo-inc.com> for telling me not to worry about
+Jeff Friedl E<lt>jfriedl@yahoo-inc.comE<gt> for telling me not to worry about
 error-checking (sort of-- you had to be there).
 
 =head1 COPYRIGHT AND LICENSE

--- a/lib/Text/ParseWords.pm
+++ b/lib/Text/ParseWords.pm
@@ -2,7 +2,7 @@ package Text::ParseWords;
 
 use strict;
 require 5.006;
-our $VERSION = "3.30";
+our $VERSION = "3.30_01";
 
 
 use Exporter;

--- a/t/taint.t
+++ b/t/taint.t
@@ -9,6 +9,10 @@ BEGIN {
             print "1..0 # Skip: Scalar::Util was not built\n";
             exit 0;
         }
+        if (exists($Config::Config{taint_support}) && not $Config::Config{taint_support}) {
+            print "1..0 # Skip: your perl was built without taint support\n";
+            exit 0;
+        }
     }
 }
 


### PR DESCRIPTION
Hi,

I've made a change to Configure for perl, to make it easier to build a perl without taint support. As part of it I'm fixing tests that ship with perl, so any taint-requiring tests are skipped if you built a taint-free Perl.

This perl is the change for Text-ParseWords. Can you ship this to CPAN please, and then submit a PR to blead, so that blead matches whatever you release to CPAN.

Thanks,
Neil
